### PR TITLE
ROR-66 Improve API query performance

### DIFF
--- a/HousingManagementSystemApi/UseCases/RetrieveAddressesUseCase.cs
+++ b/HousingManagementSystemApi/UseCases/RetrieveAddressesUseCase.cs
@@ -37,7 +37,8 @@ namespace HousingManagementSystemApi.UseCases
                 return new List<PropertyAddress>();
             var result = await addressesGateway.SearchByPostcode(postcode);
             var filteredAssets = new List<PropertyAddress>();
-            foreach (var property in result)
+
+            await Parallel.ForEachAsync(result, async (property, _) =>
             {
                 var asset = await assetGateway.RetrieveAsset(property.Reference.ID);
                 if (assetTypes.Contains(asset.AssetType))
@@ -50,7 +51,7 @@ namespace HousingManagementSystemApi.UseCases
                         filteredAssets.Add(property);
                     }
                 }
-            }
+            });
 
             return filteredAssets;
         }


### PR DESCRIPTION
The improvement was required to complete queries within AWS Lambda duration limit of 30s

The use of `Parallel.ForEachAsync` allows async lambdas (which can have `await`s within them).
More info [here](https://www.hanselman.com/blog/parallelforeachasync-in-net-6).