### PR TITLE
MR-617 - Enable logging in Address controller

### DIFF
--- a/HousingManagementSystemApi.Tests/ContollersTests/AddressControllerTests.cs
+++ b/HousingManagementSystemApi.Tests/ContollersTests/AddressControllerTests.cs
@@ -2,10 +2,12 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Castle.Core.Logging;
 using FluentAssertions;
 using HACT.Dtos;
 using HousingManagementSystemApi.Controllers;
 using HousingManagementSystemApi.UseCases;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
 
@@ -22,7 +24,7 @@ namespace HousingManagementSystemApi.Tests.ContollersTests
             postcode = "postcode";
 
             retrieveAddressesUseCaseMock = new Mock<IRetrieveAddressesUseCase>();
-            systemUnderTest = new AddressesController(retrieveAddressesUseCaseMock.Object);
+            systemUnderTest = new AddressesController(retrieveAddressesUseCaseMock.Object, new NullLogger<AddressesController>());
         }
 
         private void SetupDummyAddresses()

--- a/HousingManagementSystemApi/Controllers/AddressesController.cs
+++ b/HousingManagementSystemApi/Controllers/AddressesController.cs
@@ -3,6 +3,8 @@ using Microsoft.AspNetCore.Mvc;
 namespace HousingManagementSystemApi.Controllers
 {
     using System;
+    using System.Linq;
+    using Microsoft.Extensions.Logging;
     using Sentry;
     using UseCases;
     using Constants = HousingManagementSystemApi.Constants;
@@ -13,10 +15,12 @@ namespace HousingManagementSystemApi.Controllers
     public class AddressesController : ControllerBase
     {
         private readonly IRetrieveAddressesUseCase retrieveAddressesUseCase;
+        private readonly ILogger<AddressesController> _logger;
 
-        public AddressesController(IRetrieveAddressesUseCase retrieveAddressesUseCase)
+        public AddressesController(IRetrieveAddressesUseCase retrieveAddressesUseCase, ILogger<AddressesController> logger)
         {
             this.retrieveAddressesUseCase = retrieveAddressesUseCase;
+            _logger = logger;
         }
 
         [HttpGet]
@@ -25,11 +29,13 @@ namespace HousingManagementSystemApi.Controllers
             try
             {
                 var result = await retrieveAddressesUseCase.Execute(postcode);
+                _logger.LogInformation($"Number of results being returned by AddressesController.Address: {result.Count()} - for postcode ${postcode}");
                 return Ok(result);
             }
             catch (Exception e)
             {
                 SentrySdk.CaptureException(e);
+                _logger.LogInformation($"Error {e.Message} occurred in AddressesController.Address while retrieving address results for postcode {postcode}. Exception {e}");
                 return StatusCode(500, e.Message);
             }
         }


### PR DESCRIPTION
Enable logging in Address controller to have more information about the 500 error returned by Repairs Online Prod

![image](https://user-images.githubusercontent.com/70756861/206523769-ffcbe53f-2f9e-4e77-a7ae-5eaec0ac4dc5.png)