### PR TITLE
Added second endpoint for property eligibility verification

### DIFF
--- a/HousingManagementSystemApi.Tests/ContollersTests/AddressControllerTests.cs
+++ b/HousingManagementSystemApi.Tests/ContollersTests/AddressControllerTests.cs
@@ -18,13 +18,15 @@ namespace HousingManagementSystemApi.Tests.ContollersTests
     {
         private readonly AddressesController systemUnderTest;
         private readonly Mock<IRetrieveAddressesUseCase> retrieveAddressesUseCaseMock;
+        private readonly Mock<IVerifyPropertyEligibilityUseCase> verifyPropertyEligibilityUseCase;
         private readonly string postcode;
         public AddressControllerTests()
         {
             postcode = "postcode";
 
             retrieveAddressesUseCaseMock = new Mock<IRetrieveAddressesUseCase>();
-            systemUnderTest = new AddressesController(retrieveAddressesUseCaseMock.Object, new NullLogger<AddressesController>());
+            verifyPropertyEligibilityUseCase = new Mock<IVerifyPropertyEligibilityUseCase>();
+            systemUnderTest = new AddressesController(retrieveAddressesUseCaseMock.Object, verifyPropertyEligibilityUseCase.Object, new NullLogger<AddressesController>());
         }
 
         private void SetupDummyAddresses()

--- a/HousingManagementSystemApi.Tests/UseCasesTests/RetrieveAddressesUseCaseTests.cs
+++ b/HousingManagementSystemApi.Tests/UseCasesTests/RetrieveAddressesUseCaseTests.cs
@@ -20,29 +20,13 @@ namespace HousingManagementSystemApi.Tests
     public class RetrieveAddressesUseCaseTests
     {
         private readonly Mock<IAddressesGateway> retrieveAddressesGateway;
-        private readonly Mock<IAssetGateway> retrieveAssetGateway;
-        private readonly Mock<ITenureGateway> tenureGateway;
+
         private readonly RetrieveAddressesUseCase retrieveAddressesUseCase;
-
-        public static IEnumerable<AssetType> EligibleAssetTypes = new[]
-        {
-            AssetType.Flat, AssetType.House, AssetType.Dwelling,
-        };
-
-        private readonly List<TenureType> eligibleAssetTypes = new List<TenureType>
-        {
-            TenureTypes.Introductory,
-            TenureTypes.Secure,
-            TenureTypes.Freehold
-        };
 
         public RetrieveAddressesUseCaseTests()
         {
             retrieveAddressesGateway = new Mock<IAddressesGateway>();
-            retrieveAssetGateway = new Mock<IAssetGateway>();
-            tenureGateway = new Mock<ITenureGateway>();
             retrieveAddressesUseCase = new RetrieveAddressesUseCase(retrieveAddressesGateway.Object,
-                retrieveAssetGateway.Object, EligibleAssetTypes, tenureGateway.Object, eligibleAssetTypes,
                 new NullLogger<RetrieveAddressesUseCase>());
         }
 
@@ -62,67 +46,8 @@ namespace HousingManagementSystemApi.Tests
             retrieveAddressesGateway.Setup(x => x.SearchByPostcode(TestPostcode))
                 .ReturnsAsync(new PropertyAddress[] { new() { PostalCode = TestPostcode, Reference = new Reference { ID = "assetId" } } });
 
-            retrieveAssetGateway.Setup(x => x.RetrieveAsset("assetId"))
-                .ReturnsAsync(new AssetResponseObject { AssetType = AssetType.Dwelling, Tenure = new AssetTenureResponseObject { Id = "Id" } });
-
-            tenureGateway.Setup(x => x.RetrieveTenureType("Id"))
-                .ReturnsAsync(new TenureInformation { TenureType = TenureTypes.Secure });
-
             var result = await retrieveAddressesUseCase.Execute(TestPostcode);
             result.First().PostalCode.Should().Be(TestPostcode);
-        }
-
-        [Fact]
-        public async Task GivenAPostcode_WhenAnAddressExistsWithAnIneligibleAssetType_ThenAPropertyIsNotReturned()
-        {
-            const string TestPostcode = "postcode";
-            retrieveAddressesGateway.Setup(x => x.SearchByPostcode(TestPostcode))
-                .ReturnsAsync(new PropertyAddress[] { new() { PostalCode = TestPostcode, Reference = new Reference { ID = "assetId" } } });
-
-            retrieveAssetGateway.Setup(x => x.RetrieveAsset("assetId"))
-                .ReturnsAsync(new AssetResponseObject { AssetType = AssetType.Concierge });
-
-            tenureGateway.Setup(x => x.RetrieveTenureType("Id"))
-                .ReturnsAsync(new TenureInformation { TenureType = TenureTypes.Secure });
-
-            var result = await retrieveAddressesUseCase.Execute(TestPostcode);
-            result.Should().BeEmpty();
-        }
-
-        [Fact]
-        public async Task GivenAPostcode_WhenAnAddressExistsWithAnIneligibleTenureType_ThenAPropertyIsNotReturned()
-        {
-            const string TestPostcode = "postcode";
-            var ineligibleTenureType = TenureTypes.CommercialLet;
-            retrieveAddressesGateway.Setup(x => x.SearchByPostcode(TestPostcode))
-                .ReturnsAsync(new PropertyAddress[] { new() { PostalCode = TestPostcode, Reference = new Reference { ID = "assetId" } } });
-
-            retrieveAssetGateway.Setup(x => x.RetrieveAsset("assetId"))
-                .ReturnsAsync(new AssetResponseObject { AssetType = AssetType.Concierge });
-
-            tenureGateway.Setup(x => x.RetrieveTenureType("Id"))
-                .ReturnsAsync(new TenureInformation { TenureType = ineligibleTenureType });
-
-            var result = await retrieveAddressesUseCase.Execute(TestPostcode);
-            result.Should().BeEmpty();
-        }
-
-        [Fact]
-        public async Task GivenAPostcode_WhenAnAddressExistsWithANullTenure_ThenAPropertyIsNotReturned()
-        {
-            const string TestPostcode = "postcode";
-            var eligibleTenureType = TenureTypes.Secure;
-            retrieveAddressesGateway.Setup(x => x.SearchByPostcode(TestPostcode))
-                .ReturnsAsync(new PropertyAddress[] { new() { PostalCode = TestPostcode, Reference = new Reference { ID = "assetId" } } });
-
-            retrieveAssetGateway.Setup(x => x.RetrieveAsset("assetId"))
-                .ReturnsAsync(new AssetResponseObject { AssetType = AssetType.Dwelling });
-
-            tenureGateway.Setup(x => x.RetrieveTenureType("Id"))
-                .ReturnsAsync((TenureInformation)null);
-
-            var result = await retrieveAddressesUseCase.Execute(TestPostcode);
-            result.Should().BeEmpty();
         }
 
         [Fact]

--- a/HousingManagementSystemApi.Tests/UseCasesTests/VerifyPropertyEligibilityUseCaseTests.cs
+++ b/HousingManagementSystemApi.Tests/UseCasesTests/VerifyPropertyEligibilityUseCaseTests.cs
@@ -175,22 +175,5 @@ namespace HousingManagementSystemApi.Tests.UseCasesTests
             // Assert
             Assert.True(result.PropertyEligible);
         }
-
-        [Fact]
-        public async Task GivenAPostcode_WhenAnAddressExistsWithANullTenure_ThenAPropertyIsNotReturned()
-        {
-            const string TestPostcode = "postcode";
-            var eligibleTenureType = TenureTypes.Secure;
-
-            retrieveAssetGateway.Setup(x => x.RetrieveAsset("assetId"))
-                .ReturnsAsync(new AssetResponseObject { AssetType = AssetType.Dwelling });
-
-
-            tenureGateway.Setup(x => x.RetrieveTenureType("Id"))
-                .ReturnsAsync(new TenureInformation { TenureType = TenureTypes.Secure });
-
-            // Act
-            var result = await this.sut.Execute(TestPostcode);
-        }
     }
 }

--- a/HousingManagementSystemApi.Tests/UseCasesTests/VerifyPropertyEligibilityUseCaseTests.cs
+++ b/HousingManagementSystemApi.Tests/UseCasesTests/VerifyPropertyEligibilityUseCaseTests.cs
@@ -3,14 +3,14 @@ namespace HousingManagementSystemApi.Tests.UseCasesTests
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
-    using Moq;
-    using Xunit;
-    using HousingManagementSystemApi.Gateways;
+    using Hackney.Shared.Asset.Boundary.Response;
     using Hackney.Shared.Asset.Domain;
     using Hackney.Shared.Tenure.Domain;
-    using Hackney.Shared.Asset.Boundary.Response;
+    using HousingManagementSystemApi.Gateways;
     using HousingManagementSystemApi.UseCases;
     using Microsoft.Extensions.Logging.Abstractions;
+    using Moq;
+    using Xunit;
 
     public class VerifyPropertyEligibilityUseCaseTests
     {

--- a/HousingManagementSystemApi.Tests/UseCasesTests/VerifyPropertyEligibilityUseCaseTests.cs
+++ b/HousingManagementSystemApi.Tests/UseCasesTests/VerifyPropertyEligibilityUseCaseTests.cs
@@ -1,0 +1,196 @@
+namespace HousingManagementSystemApi.Tests.UseCasesTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Moq;
+    using Xunit;
+    using HousingManagementSystemApi.Gateways;
+    using Hackney.Shared.Asset.Domain;
+    using Hackney.Shared.Tenure.Domain;
+    using Hackney.Shared.Asset.Boundary.Response;
+    using HousingManagementSystemApi.UseCases;
+    using Microsoft.Extensions.Logging.Abstractions;
+
+    public class VerifyPropertyEligibilityUseCaseTests
+    {
+        private readonly Mock<IAssetGateway> retrieveAssetGateway;
+        private readonly Mock<ITenureGateway> tenureGateway;
+        private readonly VerifyPropertyEligibilityUseCase sut;
+
+        public static IEnumerable<AssetType> EligibleAssetTypes = new[]
+{
+            AssetType.Flat, AssetType.House, AssetType.Dwelling,
+        };
+
+        private readonly List<TenureType> eligibleTenureTypes = new()
+        {
+            TenureTypes.Introductory,
+            TenureTypes.Secure,
+            TenureTypes.Freehold
+        };
+
+        public VerifyPropertyEligibilityUseCaseTests()
+        {
+            this.retrieveAssetGateway = new Mock<IAssetGateway>();
+            this.tenureGateway = new Mock<ITenureGateway>();
+            this.sut = new VerifyPropertyEligibilityUseCase(retrieveAssetGateway.Object, EligibleAssetTypes, tenureGateway.Object, eligibleTenureTypes, new NullLogger<VerifyPropertyEligibilityUseCase>());
+        }
+
+        [Fact]
+        public async Task GivenANullPropertyId_WhenUseCaseIsExecuted_ThenAnExceptionShouldBeThrown()
+        {
+            // Act
+            var action = async () => await this.sut.Execute(null);
+
+            // Assert
+            await Assert.ThrowsAsync<ArgumentNullException>(action);
+        }
+
+        [Fact]
+        public async Task GivenAssetCannotBeFound_WhenUseCaseIsExecuted_ThenThereWillBeAFailureResult()
+        {
+            // Arrange
+            const string HouseThatDoesntExist = "Missing";
+
+            retrieveAssetGateway.Setup(x => x.RetrieveAsset(HouseThatDoesntExist))
+                .ReturnsAsync((AssetResponseObject)null);
+
+            tenureGateway.Setup(x => x.RetrieveTenureType(It.IsAny<string>()))
+                .ReturnsAsync(new TenureInformation { TenureType = TenureTypes.Secure });
+
+            // Act
+            var result = await this.sut.Execute(HouseThatDoesntExist);
+
+            // Assert
+            Assert.False(result.PropertyEligible);
+            Assert.Contains("The asset with property ID", result.Reason);
+            Assert.Contains("cannot be found", result.Reason);
+        }
+
+        [Fact]
+        public async Task GivenAssetWithAnInvalidAssetType_WhenUseCaseIsExecuted_ThenThereWillBeAFailureResult()
+        {
+            // Arrange
+            const string HouseThatExists = "01234567";
+
+            retrieveAssetGateway.Setup(x => x.RetrieveAsset(HouseThatExists))
+                .ReturnsAsync(new AssetResponseObject
+                {
+                    AssetType = AssetType.TravellerSite,
+                    Tenure = new AssetTenureResponseObject
+                    {
+                        Id = "TEN001"
+                    }
+                });
+
+            tenureGateway.Setup(x => x.RetrieveTenureType("TEN001"))
+                .ReturnsAsync(new TenureInformation { TenureType = TenureTypes.Secure });
+
+            // Act
+            var result = await this.sut.Execute(HouseThatExists);
+
+            // Assert
+            Assert.False(result.PropertyEligible);
+            Assert.Contains("is not eligible because of the asset type", result.Reason);
+        }
+
+        [Fact]
+        public async Task GivenAssetWithANullTenure_WhenUseCaseIsExecuted_ThenThereWillBeAFailureResult()
+        {
+            // Arrange
+            const string HouseThatExists = "01234567";
+
+            retrieveAssetGateway.Setup(x => x.RetrieveAsset(HouseThatExists))
+                .ReturnsAsync(new AssetResponseObject
+                {
+                    AssetType = AssetType.Dwelling,
+                    Tenure = new AssetTenureResponseObject
+                    {
+                        Id = "TEN001"
+                    }
+                });
+
+            tenureGateway.Setup(x => x.RetrieveTenureType("TEN001"))
+                .ReturnsAsync((TenureInformation)null);
+
+
+            // Act
+            var result = await this.sut.Execute(HouseThatExists);
+
+            // Assert
+            Assert.False(result.PropertyEligible);
+            Assert.Contains("Tenure type code was null for asset", result.Reason);
+        }
+
+        [Fact]
+        public async Task GivenAssetWithAnInvalidTenureType_WhenUseCaseIsExecuted_ThenThereWillBeAFailureResult()
+        {
+            // Arrange
+            const string HouseThatExists = "01234567";
+
+            retrieveAssetGateway.Setup(x => x.RetrieveAsset(HouseThatExists))
+                .ReturnsAsync(new AssetResponseObject
+                {
+                    AssetType = AssetType.Dwelling,
+                    Tenure = new AssetTenureResponseObject
+                    {
+                        Id = "TEN001"
+                    }
+                });
+
+            tenureGateway.Setup(x => x.RetrieveTenureType("TEN001"))
+                .ReturnsAsync(new TenureInformation { TenureType = TenureTypes.AsylumSeeker });
+
+            // Act
+            var result = await this.sut.Execute(HouseThatExists);
+
+            // Assert
+            Assert.False(result.PropertyEligible);
+            Assert.Contains("is not suitable for Online Repairs", result.Reason);
+        }
+
+        [Fact]
+        public async Task GivenAllValidData_WhenUseCaseIsExecuted_ThenShouldBeASuccessfulValidation()
+        {
+            // Arrange
+            const string HouseThatExists = "01234567";
+
+            retrieveAssetGateway.Setup(x => x.RetrieveAsset(HouseThatExists))
+                .ReturnsAsync(new AssetResponseObject
+                {
+                    AssetType = AssetType.Dwelling,
+                    Tenure = new AssetTenureResponseObject
+                    {
+                        Id = "TEN001"
+                    }
+                });
+
+            tenureGateway.Setup(x => x.RetrieveTenureType("TEN001"))
+                .ReturnsAsync(new TenureInformation { TenureType = TenureTypes.Secure });
+
+            // Act
+            var result = await this.sut.Execute(HouseThatExists);
+
+            // Assert
+            Assert.True(result.PropertyEligible);
+        }
+
+        [Fact]
+        public async Task GivenAPostcode_WhenAnAddressExistsWithANullTenure_ThenAPropertyIsNotReturned()
+        {
+            const string TestPostcode = "postcode";
+            var eligibleTenureType = TenureTypes.Secure;
+
+            retrieveAssetGateway.Setup(x => x.RetrieveAsset("assetId"))
+                .ReturnsAsync(new AssetResponseObject { AssetType = AssetType.Dwelling });
+
+
+            tenureGateway.Setup(x => x.RetrieveTenureType("Id"))
+                .ReturnsAsync(new TenureInformation { TenureType = TenureTypes.Secure });
+
+            // Act
+            var result = await this.sut.Execute(TestPostcode);
+        }
+    }
+}

--- a/HousingManagementSystemApi/Controllers/AddressesController.cs
+++ b/HousingManagementSystemApi/Controllers/AddressesController.cs
@@ -27,6 +27,7 @@ namespace HousingManagementSystemApi.Controllers
         }
 
         [HttpGet]
+        [Route("addresses")]
         public async Task<IActionResult> Address([FromQuery] string postcode)
         {
             try
@@ -44,6 +45,7 @@ namespace HousingManagementSystemApi.Controllers
         }
 
         [HttpGet]
+        [Route("propertyeligible")]
         public async Task<IActionResult> VerifyPropertyEligibility([FromQuery] string propertyId)
         {
             _logger.LogInformation($"Verifying property eligibility for property {propertyId}");

--- a/HousingManagementSystemApi/Controllers/AddressesController.cs
+++ b/HousingManagementSystemApi/Controllers/AddressesController.cs
@@ -46,6 +46,8 @@ namespace HousingManagementSystemApi.Controllers
         [HttpGet]
         public async Task<IActionResult> VerifyPropertyEligibility([FromQuery] string propertyId)
         {
+            _logger.LogInformation($"Verifying property eligibility for property {propertyId}");
+
             try
             {
                 var result = await verifyPropertyEligibilityUseCase.Execute(propertyId);

--- a/HousingManagementSystemApi/Controllers/AddressesController.cs
+++ b/HousingManagementSystemApi/Controllers/AddressesController.cs
@@ -4,6 +4,7 @@ namespace HousingManagementSystemApi.Controllers
 {
     using System;
     using System.Linq;
+    using HACT.Dtos;
     using Microsoft.Extensions.Logging;
     using Sentry;
     using UseCases;
@@ -15,11 +16,13 @@ namespace HousingManagementSystemApi.Controllers
     public class AddressesController : ControllerBase
     {
         private readonly IRetrieveAddressesUseCase retrieveAddressesUseCase;
+        private readonly IVerifyPropertyEligibilityUseCase verifyPropertyEligibilityUseCase;
         private readonly ILogger<AddressesController> _logger;
 
-        public AddressesController(IRetrieveAddressesUseCase retrieveAddressesUseCase, ILogger<AddressesController> logger)
+        public AddressesController(IRetrieveAddressesUseCase retrieveAddressesUseCase, IVerifyPropertyEligibilityUseCase verifyPropertyEligibilityUseCase, ILogger<AddressesController> logger)
         {
             this.retrieveAddressesUseCase = retrieveAddressesUseCase;
+            this.verifyPropertyEligibilityUseCase = verifyPropertyEligibilityUseCase;
             _logger = logger;
         }
 
@@ -36,6 +39,21 @@ namespace HousingManagementSystemApi.Controllers
             {
                 SentrySdk.CaptureException(e);
                 _logger.LogInformation($"Error {e.Message} occurred in AddressesController.Address while retrieving address results for postcode {postcode}. Exception {e}");
+                return StatusCode(500, e.Message);
+            }
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> VerifyPropertyEligibility([FromQuery] string propertyId)
+        {
+            try
+            {
+                var result = await verifyPropertyEligibilityUseCase.Execute(propertyId);
+                return Ok(result);
+            }
+            catch (Exception e)
+            {
+                SentrySdk.CaptureException(e);
                 return StatusCode(500, e.Message);
             }
         }

--- a/HousingManagementSystemApi/Models/PropertyEligibilityResult.cs
+++ b/HousingManagementSystemApi/Models/PropertyEligibilityResult.cs
@@ -1,0 +1,14 @@
+namespace HousingManagementSystemApi.Models
+{
+    public class PropertyEligibilityResult
+    {
+        public PropertyEligibilityResult(bool propertyEligible, string reason)
+        {
+            this.PropertyEligible = propertyEligible;
+            this.Reason = reason;
+        }
+
+        public bool PropertyEligible { get; set; }
+        public string Reason { get; set; }
+    }
+}

--- a/HousingManagementSystemApi/Startup.cs
+++ b/HousingManagementSystemApi/Startup.cs
@@ -50,13 +50,19 @@ namespace HousingManagementSystemApi
 
             services.AddTransient<IRetrieveAddressesUseCase, RetrieveAddressesUseCase>(s =>
             {
-                var tenureGateway = s.GetService<ITenureGateway>();
-                var assetGateway = s.GetService<IAssetGateway>();
                 var addressesGateway = s.GetService<IAddressesGateway>();
+                var logger = s.GetService<ILogger<RetrieveAddressesUseCase>>();
+                return new RetrieveAddressesUseCase(addressesGateway, logger);
+            });
+
+            services.AddTransient<IVerifyPropertyEligibilityUseCase, VerifyPropertyEligibilityUseCase>(s =>
+            {
+                var assetGateway = s.GetService<IAssetGateway>();
+                var tenureGateway = s.GetService<ITenureGateway>();
                 var eligibleAssets = EligibleAssetTypes;
                 var eligibleTenureTypes = EligibleTenureTypes;
-                var logger = s.GetService<ILogger<RetrieveAddressesUseCase>>();
-                return new RetrieveAddressesUseCase(addressesGateway, assetGateway, eligibleAssets, tenureGateway, eligibleTenureTypes, logger);
+                var logger = s.GetService<ILogger<VerifyPropertyEligibilityUseCase>>();
+                return new VerifyPropertyEligibilityUseCase(assetGateway, eligibleAssets, tenureGateway, eligibleTenureTypes, logger);
             });
 
             AddHttpClients(services);

--- a/HousingManagementSystemApi/Startup.cs
+++ b/HousingManagementSystemApi/Startup.cs
@@ -9,14 +9,11 @@ using Microsoft.OpenApi.Models;
 namespace HousingManagementSystemApi
 {
     using System.Collections.Generic;
-    using System.Net.Http;
-    using Castle.Core.Logging;
     using Gateways;
     using Hackney.Shared.Asset.Domain;
     using Hackney.Shared.Tenure.Domain;
     using HousingRepairsOnline.Authentication.DependencyInjection;
     using Microsoft.Extensions.Logging;
-    using Microsoft.Extensions.Logging.Abstractions;
     using UseCases;
 
     public class Startup

--- a/HousingManagementSystemApi/UseCases/IVerifyPropertyEligibilityUseCase.cs
+++ b/HousingManagementSystemApi/UseCases/IVerifyPropertyEligibilityUseCase.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using HACT.Dtos;
+using HousingManagementSystemApi.Models;
+
+namespace HousingManagementSystemApi.UseCases
+{
+    public interface IVerifyPropertyEligibilityUseCase
+    {
+        public Task<PropertyEligibilityResult> Execute(string propertyId);
+    }
+}

--- a/HousingManagementSystemApi/UseCases/RetrieveAddressesUseCase.cs
+++ b/HousingManagementSystemApi/UseCases/RetrieveAddressesUseCase.cs
@@ -16,26 +16,13 @@ namespace HousingManagementSystemApi.UseCases
     public class RetrieveAddressesUseCase : IRetrieveAddressesUseCase
     {
         private readonly IAddressesGateway _addressesGateway;
-        private readonly IAssetGateway _assetGateway;
-        private readonly IEnumerable<AssetType> _assetTypes;
-        private readonly ITenureGateway _tenureGateway;
         private readonly ILogger<RetrieveAddressesUseCase> _logger;
-
-        private IEnumerable<string> EligibleTenureCodes { get; }
 
         public RetrieveAddressesUseCase(
             IAddressesGateway addressesGateway,
-            IAssetGateway assetGateway,
-            IEnumerable<AssetType> assetTypes,
-            ITenureGateway tenureGateway,
-            IEnumerable<TenureType> eligibleTenureTypes,
             ILogger<RetrieveAddressesUseCase> logger)
         {
             _addressesGateway = addressesGateway;
-            _assetGateway = assetGateway;
-            _assetTypes = assetTypes;
-            _tenureGateway = tenureGateway;
-            EligibleTenureCodes = eligibleTenureTypes.Select(x => x.Code);
             _logger = logger;
         }
 
@@ -48,66 +35,11 @@ namespace HousingManagementSystemApi.UseCases
                 _logger.LogInformation("The value of {PostCode} was null or whitespace. Throwing Exception", postCode);
                 throw new ArgumentNullException(nameof(postCode));
             }
-
             var result = await _addressesGateway.SearchByPostcode(postCode);
 
             _logger.LogInformation("Retrieved {Count} results from addressGateway for {PostCode}", result.Count(), postCode);
 
-            var filteredAssets = new List<PropertyAddress>();
-
-            await Parallel.ForEachAsync(result, async (property, _) =>
-            {
-                var filteredAsset = await FilterAsset(property, postCode);
-
-                if (filteredAsset != null)
-                {
-                    filteredAssets.Add(filteredAsset);
-                }
-            });
-
-            _logger.LogInformation("Returning {Count} filteredAssets from RetrieveAddressesUseCase for {PostCode}", filteredAssets.Count(), postCode);
-
-            return filteredAssets;
-        }
-
-        private async Task<PropertyAddress> FilterAsset(PropertyAddress property, string postCode)
-        {
-            var asset = await _assetGateway.RetrieveAsset(property.Reference.ID);
-
-            if (asset == null)
-            {
-                _logger.LogInformation("The asset with {Id} returned null for postCode {PostCode}. Skipping iteration", property.Reference.ID, postCode);
-                return null;
-            }
-
-            if (!_assetTypes.Contains(asset.AssetType))
-            {
-                _logger.LogInformation("The asset with {Id} was skipped because the assetType was {AssetType} for postCode {PostCode}. Skipping iteration", property.Reference.ID, asset.AssetType, postCode);
-                return null;
-            }
-
-            if (asset.Tenure == null || asset.Tenure.Id == null)
-            {
-                _logger.LogInformation("Tenure or TenureId was null for postCode {PostCode}. Skipping iteration", postCode);
-                return null;
-            }
-
-            var tenureInformation = await _tenureGateway.RetrieveTenureType(asset?.Tenure?.Id);
-            var tenureTypeCode = tenureInformation?.TenureType?.Code;
-
-            if (tenureTypeCode == null)
-            {
-                _logger.LogInformation("TenureTypeCode was null for postCode {PostCode}. Skipping iteration", postCode);
-                return null;
-            }
-
-            if (!EligibleTenureCodes.Contains(tenureTypeCode))
-            {
-                _logger.LogInformation("The asset was skipped because tenureTypeCode was {TenureTypeCode} for postCode {PostCode}. Skipping iteration", tenureTypeCode, postCode);
-                return null;
-            }
-
-            return property;
+            return result;
         }
     }
 }

--- a/HousingManagementSystemApi/UseCases/VerifyPropertyEligibilityUseCase.cs
+++ b/HousingManagementSystemApi/UseCases/VerifyPropertyEligibilityUseCase.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using HACT.Dtos;
+using HousingManagementSystemApi.Gateways;
+
+namespace HousingManagementSystemApi.UseCases
+{
+    using System.Linq;
+    using System.Reflection.Metadata.Ecma335;
+    using Amazon.Runtime.Internal.Util;
+    using Hackney.Shared.Asset.Domain;
+    using Hackney.Shared.Tenure.Domain;
+    using HousingManagementSystemApi.Models;
+    using Microsoft.Extensions.Logging;
+
+    public class VerifyPropertyEligibilityUseCase : IVerifyPropertyEligibilityUseCase
+    {
+        private readonly IAssetGateway _assetGateway;
+        private readonly IEnumerable<AssetType> _assetTypes;
+        private readonly ITenureGateway _tenureGateway;
+        private readonly ILogger<VerifyPropertyEligibilityUseCase> _logger;
+
+        private IEnumerable<string> EligibleTenureCodes { get; }
+
+        public VerifyPropertyEligibilityUseCase(
+            IAssetGateway assetGateway,
+            IEnumerable<AssetType> assetTypes,
+            ITenureGateway tenureGateway,
+            IEnumerable<TenureType> eligibleTenureTypes,
+            ILogger<VerifyPropertyEligibilityUseCase> logger)
+        {
+            _assetGateway = assetGateway;
+            _assetTypes = assetTypes;
+            _tenureGateway = tenureGateway;
+            EligibleTenureCodes = eligibleTenureTypes.Select(x => x.Code);
+            _logger = logger;
+        }
+
+        public async Task<PropertyEligibilityResult> Execute(string propertyId)
+        {
+            _logger.LogInformation("Calling VerifyPropertyEligibilityUseCase for {PropertyId}", propertyId);
+
+            if (string.IsNullOrEmpty(propertyId))
+            {
+                _logger.LogInformation("The property ID {PropertyId} was null or empty. Throwing Exception", propertyId);
+                throw new ArgumentNullException(nameof(propertyId));
+            }
+
+            var asset = await _assetGateway.RetrieveAsset(propertyId);
+
+            if (asset == null)
+            {
+                _logger.LogInformation("The asset with property ID {Id} cannot be found", propertyId);
+                return new PropertyEligibilityResult(false, $"The asset with property ID {propertyId} cannot be found");
+            }
+
+            if (!_assetTypes.Contains(asset.AssetType))
+            {
+                _logger.LogInformation("The asset with {PropertyId} is not eligible because of the asset type", propertyId);
+                return new PropertyEligibilityResult(false, $"The asset with {propertyId} is not eligible because of the asset type");
+            }
+
+            if (asset.Tenure == null || asset.Tenure.Id == null)
+            {
+                _logger.LogInformation("Tenure or TenureId was null for postCode {PropertyId}", propertyId);
+                return new PropertyEligibilityResult(false, $"The asset with {propertyId} has no valid tenure");
+            }
+
+            var tenureInformation = await _tenureGateway.RetrieveTenureType(asset?.Tenure?.Id);
+            var tenureTypeCode = tenureInformation?.TenureType?.Code;
+
+            if (tenureTypeCode == null)
+            {
+                _logger.LogInformation("TenureTypeCode was null for asset with property ID {PropertyId}", propertyId);
+                return new PropertyEligibilityResult(false, $"TenureTypeCode was null for asset with property ID {propertyId}");
+            }
+
+            if (!EligibleTenureCodes.Contains(tenureTypeCode))
+            {
+                _logger.LogInformation("TenureTypeCode for asset with property ID {PropertyId} is not suitable for Online Repairs", propertyId);
+                return new PropertyEligibilityResult(false, $"TenureTypeCode for asset with property ID {propertyId} is not suitable for Online Repairs. Skipping iteration");
+            }
+
+            return new PropertyEligibilityResult(true, "The property is valid");
+        }
+    }
+}

--- a/HousingManagementSystemApi/UseCases/VerifyPropertyEligibilityUseCase.cs
+++ b/HousingManagementSystemApi/UseCases/VerifyPropertyEligibilityUseCase.cs
@@ -72,14 +72,14 @@ namespace HousingManagementSystemApi.UseCases
 
             if (tenureTypeCode == null)
             {
-                _logger.LogInformation("TenureTypeCode was null for asset with property ID {PropertyId}", propertyId);
-                return new PropertyEligibilityResult(false, $"TenureTypeCode was null for asset with property ID {propertyId}");
+                _logger.LogInformation("Tenure type code was null for asset with property ID {PropertyId}", propertyId);
+                return new PropertyEligibilityResult(false, $"Tenure type code was null for asset with property ID {propertyId}");
             }
 
             if (!EligibleTenureCodes.Contains(tenureTypeCode))
             {
                 _logger.LogInformation("TenureTypeCode for asset with property ID {PropertyId} is not suitable for Online Repairs", propertyId);
-                return new PropertyEligibilityResult(false, $"TenureTypeCode for asset with property ID {propertyId} is not suitable for Online Repairs. Skipping iteration");
+                return new PropertyEligibilityResult(false, $"Tenure type for property {propertyId} is not suitable for Online Repairs");
             }
 
             return new PropertyEligibilityResult(true, "The property is valid");

--- a/HousingManagementSystemApi/UseCases/VerifyPropertyEligibilityUseCase.cs
+++ b/HousingManagementSystemApi/UseCases/VerifyPropertyEligibilityUseCase.cs
@@ -63,7 +63,7 @@ namespace HousingManagementSystemApi.UseCases
 
             if (asset.Tenure == null || asset.Tenure.Id == null)
             {
-                _logger.LogInformation("Tenure or TenureId was null for postCode {PropertyId}", propertyId);
+                _logger.LogInformation("Tenure or TenureId was null for {PropertyId}", propertyId);
                 return new PropertyEligibilityResult(false, $"The asset with {propertyId} has no valid tenure");
             }
 


### PR DESCRIPTION
- Split Retrieve Addresses into two
- Add tests

Angelo's latest changes (12/12):
The AddressGateway (screenshot below) in HousingRepairsOnlineApi sends request to HousingManagementSystemApi and the routes are the following: 

- Search (EXISTING ADDRESS SEARCH ENDPOINT)- `"addresses?postcode={postcode}"`
- VerifyAddressEligibility (NEW ENDPOINT) - `"propertyeligible?propertyid={propertyId}"`

![image](https://user-images.githubusercontent.com/70756861/207123333-8fed09cf-9cb7-4376-a801-4e0344a622b8.png)

So, as we have 2 GET endpoints in HousingManagementSystemApi.AddressesController the routes are now explicit to reflect the above:
![image](https://user-images.githubusercontent.com/70756861/207123791-658a5695-cc55-4bad-bf9f-8272646b9a1c.png)



