### PR TITLE
MR-617 - Removed explicit route attribute for Address endpoint 

### DIFF
--- a/HousingManagementSystemApi/Controllers/AddressesController.cs
+++ b/HousingManagementSystemApi/Controllers/AddressesController.cs
@@ -27,7 +27,6 @@ namespace HousingManagementSystemApi.Controllers
         }
 
         [HttpGet]
-        [Route("addresses")]
         public async Task<IActionResult> Address([FromQuery] string postcode)
         {
             try


### PR DESCRIPTION
Adding the explicit route changed the endpoint URI, which will cause issue when the OnlineRepairsAPI will try and send request to this endpoint to fetch addresses.

By removing the route we're resetting the endpoint URI to what it was.