### PR TITLE
MR-634 - Add exclusion for TMO-managed properties

### DIFF
--- a/HousingManagementSystemApi.Tests/UseCasesTests/VerifyPropertyEligibilityUseCaseTests.cs
+++ b/HousingManagementSystemApi.Tests/UseCasesTests/VerifyPropertyEligibilityUseCaseTests.cs
@@ -189,7 +189,7 @@ namespace HousingManagementSystemApi.Tests.UseCasesTests
         }
 
         [Fact]
-        public async Task GivenAMissingAssetManagementRecord_WhenUseCaseIsExecuted_ThenShouldBeASuccessfulValidation()
+        public async Task GivenAMissingAssetManagementRecord_WhenUseCaseIsExecuted_ThenShouldBeAFailureResult()
         {
             // Arrange
             const string HouseThatExists = "01234567";

--- a/HousingManagementSystemApi.Tests/UseCasesTests/VerifyPropertyEligibilityUseCaseTests.cs
+++ b/HousingManagementSystemApi.Tests/UseCasesTests/VerifyPropertyEligibilityUseCaseTests.cs
@@ -108,6 +108,10 @@ namespace HousingManagementSystemApi.Tests.UseCasesTests
                     Tenure = new AssetTenureResponseObject
                     {
                         Id = "TEN001"
+                    },
+                    AssetManagement = new AssetManagement
+                    {
+                        IsTMOManaged = false,
                     }
                 });
 
@@ -136,6 +140,10 @@ namespace HousingManagementSystemApi.Tests.UseCasesTests
                     Tenure = new AssetTenureResponseObject
                     {
                         Id = "TEN001"
+                    },
+                    AssetManagement = new AssetManagement
+                    {
+                        IsTMOManaged = false,
                     }
                 });
 
@@ -163,6 +171,10 @@ namespace HousingManagementSystemApi.Tests.UseCasesTests
                     Tenure = new AssetTenureResponseObject
                     {
                         Id = "TEN001"
+                    },
+                    AssetManagement = new AssetManagement
+                    {
+                        IsTMOManaged = false,
                     }
                 });
 
@@ -174,6 +186,64 @@ namespace HousingManagementSystemApi.Tests.UseCasesTests
 
             // Assert
             Assert.True(result.PropertyEligible);
+        }
+
+        [Fact]
+        public async Task GivenAMissingAssetManagementRecord_WhenUseCaseIsExecuted_ThenShouldBeASuccessfulValidation()
+        {
+            // Arrange
+            const string HouseThatExists = "01234567";
+
+            retrieveAssetGateway.Setup(x => x.RetrieveAsset(HouseThatExists))
+                .ReturnsAsync(new AssetResponseObject
+                {
+                    AssetType = AssetType.Dwelling,
+                    Tenure = new AssetTenureResponseObject
+                    {
+                        Id = "TEN001"
+                    }
+                });
+
+            tenureGateway.Setup(x => x.RetrieveTenureType("TEN001"))
+                .ReturnsAsync(new TenureInformation { TenureType = TenureTypes.Secure });
+
+            // Act
+            var result = await this.sut.Execute(HouseThatExists);
+
+            // Assert
+            Assert.False(result.PropertyEligible);
+            Assert.Contains("Can't find TMO status for", result.Reason);
+        }
+
+        [Fact]
+        public async Task GivenATmoManagedProperty_WhenUseCaseIsExecuted_ThenShouldBeAFailureResult()
+        {
+            // Arrange
+            const string HouseThatExists = "01234567";
+
+            retrieveAssetGateway.Setup(x => x.RetrieveAsset(HouseThatExists))
+                .ReturnsAsync(new AssetResponseObject
+                {
+                    AssetType = AssetType.Dwelling,
+                    Tenure = new AssetTenureResponseObject
+                    {
+                        Id = "TEN001"
+                    },
+                    AssetManagement = new AssetManagement
+                    {
+                        IsTMOManaged = true,
+                    }
+                });
+
+            tenureGateway.Setup(x => x.RetrieveTenureType("TEN001"))
+                .ReturnsAsync(new TenureInformation { TenureType = TenureTypes.Secure });
+
+            // Act
+            var result = await this.sut.Execute(HouseThatExists);
+
+            // Assert
+            Assert.False(result.PropertyEligible);
+            Assert.Contains("is managed by a TMO", result.Reason);
         }
     }
 }

--- a/HousingManagementSystemApi/UseCases/VerifyPropertyEligibilityUseCase.cs
+++ b/HousingManagementSystemApi/UseCases/VerifyPropertyEligibilityUseCase.cs
@@ -67,6 +67,19 @@ namespace HousingManagementSystemApi.UseCases
                 return new PropertyEligibilityResult(false, $"The asset with {propertyId} has no valid tenure");
             }
 
+            if (asset.AssetManagement == null)
+            {
+                _logger.LogInformation("Can't find TMO status for property {PropertyId}", propertyId);
+                return new PropertyEligibilityResult(false, $"Can't find TMO status for {propertyId}");
+            }
+
+            if (asset.AssetManagement.IsTMOManaged)
+            {
+                _logger.LogInformation("Property {PropertyId} is ineligible due to being managed by a TMO", propertyId);
+                return new PropertyEligibilityResult(false, $"Asset {propertyId} is managed by a TMO");
+
+            }
+
             var tenureInformation = await _tenureGateway.RetrieveTenureType(asset?.Tenure?.Id);
             var tenureTypeCode = tenureInformation?.TenureType?.Code;
 


### PR DESCRIPTION
- Previously, TMO management status did not have a bearing on the eligibility of properties for repair
- Following stakeholder sign-off, this is a requirement
- Examples of properties (also on ticket):

**TMO example**: 8 Oberon House (asset: 77f72b3c-a453-1948-0254-2548c709912e)

assetManagement.isTMOManaged == true

assetManagement.managingOrganisation == North & South Arden TMO


**Non-TMO example**: 12 Pitcairn House (asset: 2d13b5cb-baf2-91fd-c231-8c5c2ee9548c)

assetManagement.isTMOManaged == false

assetManagement.managingOrganisation == London Borough of Hackney
