### PR TITLE
Added logging (to troubleshoot issue with eligibility verification of assets for Repairs Online) 

### DIFF
--- a/HousingManagementSystemApi.Tests/GatewaysTests/AssetGatewayTests.cs
+++ b/HousingManagementSystemApi.Tests/GatewaysTests/AssetGatewayTests.cs
@@ -38,7 +38,7 @@ namespace HousingManagementSystemApi.Tests.GatewaysTests
 
             var httpClientFactory = new Mock<IHttpClientFactory>();
             httpClientFactory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
-            systemUnderTest = new AssetGateway(httpClientFactory.Object, new NullLogger<AssetGateway>());
+            _systemUnderTest = new AssetGateway(httpClientFactory.Object, new NullLogger<AssetGateway>());
         }
 
         [Theory]

--- a/HousingManagementSystemApi.Tests/GatewaysTests/AssetGatewayTests.cs
+++ b/HousingManagementSystemApi.Tests/GatewaysTests/AssetGatewayTests.cs
@@ -7,6 +7,7 @@ namespace HousingManagementSystemApi.Tests.GatewaysTests
     using FluentAssertions;
     using Gateways;
     using Hackney.Shared.Asset.Boundary.Response;
+    using Microsoft.Extensions.Logging.Abstractions;
     using Moq;
     using RichardSzalay.MockHttp;
     using Xunit;
@@ -37,7 +38,7 @@ namespace HousingManagementSystemApi.Tests.GatewaysTests
 
             var httpClientFactory = new Mock<IHttpClientFactory>();
             httpClientFactory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
-            systemUnderTest = new AssetGateway(httpClientFactory.Object);
+            systemUnderTest = new AssetGateway(httpClientFactory.Object, new NullLogger<AssetGateway>());
         }
 
         [Theory]

--- a/HousingManagementSystemApi/Gateways/AssetGateway.cs
+++ b/HousingManagementSystemApi/Gateways/AssetGateway.cs
@@ -10,19 +10,19 @@ using Microsoft.Extensions.Logging;
 
 public class AssetGateway : IAssetGateway
 {
-    private readonly IHttpClientFactory httpClientFactory;
-    private readonly ILogger<AssetGateway> logger;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<AssetGateway> _logger;
 
 
     public AssetGateway(IHttpClientFactory httpClientFactory, ILogger<AssetGateway> logger)
     {
-        this.httpClientFactory = httpClientFactory;
-        this.logger = logger;
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
     }
 
     public async Task<AssetResponseObject> RetrieveAsset(string assetId)
     {
-        this.logger.LogInformation("Calling Asset API to retrieve asset for assetId {AssetId}", assetId);
+        _logger.LogInformation("Calling Asset API to retrieve asset for assetId {AssetId}", assetId);
 
         Guard.Against.NullOrWhiteSpace(assetId, nameof(assetId));
 

--- a/HousingManagementSystemApi/Gateways/AssetGateway.cs
+++ b/HousingManagementSystemApi/Gateways/AssetGateway.cs
@@ -34,7 +34,7 @@ public class AssetGateway : IAssetGateway
         var data = new AssetResponseObject();
         if (response.StatusCode == HttpStatusCode.OK)
         {
-            this.logger.LogInformation("Received status code 200 from Asset API, when attempting to retrieve asset for assetId {AssetId}", assetId);
+            _logger.LogInformation("Received status code 200 from Asset API, when attempting to retrieve asset for assetId {AssetId}", assetId);
             data = await response.Content.ReadFromJsonAsync<AssetResponseObject>();
         }
 

--- a/HousingManagementSystemApi/Gateways/AssetGateway.cs
+++ b/HousingManagementSystemApi/Gateways/AssetGateway.cs
@@ -6,18 +6,24 @@ using System.Net.Http.Json;
 using System.Threading.Tasks;
 using Ardalis.GuardClauses;
 using Hackney.Shared.Asset.Boundary.Response;
+using Microsoft.Extensions.Logging;
 
 public class AssetGateway : IAssetGateway
 {
     private readonly IHttpClientFactory httpClientFactory;
+    private readonly ILogger<AssetGateway> logger;
 
-    public AssetGateway(IHttpClientFactory httpClientFactory)
+
+    public AssetGateway(IHttpClientFactory httpClientFactory, ILogger<AssetGateway> logger)
     {
         this.httpClientFactory = httpClientFactory;
+        this.logger = logger;
     }
 
     public async Task<AssetResponseObject> RetrieveAsset(string assetId)
     {
+        this.logger.LogInformation("Calling Asset API to retrieve asset for assetId {AssetId}", assetId);
+
         Guard.Against.NullOrWhiteSpace(assetId, nameof(assetId));
 
         var httpClient = httpClientFactory.CreateClient(HttpClientNames.Asset);
@@ -28,6 +34,7 @@ public class AssetGateway : IAssetGateway
         var data = new AssetResponseObject();
         if (response.StatusCode == HttpStatusCode.OK)
         {
+            this.logger.LogInformation("Received status code 200 from Asset API, when attempting to retrieve asset for assetId {AssetId}", assetId);
             data = await response.Content.ReadFromJsonAsync<AssetResponseObject>();
         }
 

--- a/HousingManagementSystemApi/UseCases/VerifyPropertyEligibilityUseCase.cs
+++ b/HousingManagementSystemApi/UseCases/VerifyPropertyEligibilityUseCase.cs
@@ -51,20 +51,20 @@ namespace HousingManagementSystemApi.UseCases
 
             if (asset == null)
             {
-                _logger.LogInformation("The asset with property ID {Id} cannot be found", propertyId);
+                _logger.LogInformation("The asset with property ID {PropertyId} cannot be found", propertyId);
                 return new PropertyEligibilityResult(false, $"The asset with property ID {propertyId} cannot be found");
             }
 
             if (!_assetTypes.Contains(asset.AssetType))
             {
-                _logger.LogInformation("The asset with {PropertyId} is not eligible because of the asset type", propertyId);
+                _logger.LogInformation("The asset with property ID {PropertyId} is not eligible because of the asset type", propertyId);
                 return new PropertyEligibilityResult(false, $"The asset with {propertyId} is not eligible because of the asset type");
             }
 
             if (asset.Tenure == null || asset.Tenure.Id == null)
             {
-                _logger.LogInformation("Tenure or TenureId was null for {PropertyId}", propertyId);
-                return new PropertyEligibilityResult(false, $"The asset with {propertyId} has no valid tenure");
+                _logger.LogInformation("Tenure or TenureId was null for property ID {PropertyId}", propertyId);
+                return new PropertyEligibilityResult(false, $"The asset with property ID {propertyId} has no valid tenure");
             }
 
             var tenureInformation = await _tenureGateway.RetrieveTenureType(asset?.Tenure?.Id);
@@ -79,7 +79,7 @@ namespace HousingManagementSystemApi.UseCases
             if (!EligibleTenureCodes.Contains(tenureTypeCode))
             {
                 _logger.LogInformation("TenureTypeCode for asset with property ID {PropertyId} is not suitable for Online Repairs", propertyId);
-                return new PropertyEligibilityResult(false, $"Tenure type for property {propertyId} is not suitable for Online Repairs");
+                return new PropertyEligibilityResult(false, $"Tenure type for property ID {propertyId} is not suitable for Online Repairs");
             }
 
             return new PropertyEligibilityResult(true, "The property is valid");


### PR DESCRIPTION
Following an issue with a seemingly OK property on Repairs Online receiving the 'Unsuitable Property' message, I'm adding logs to this API to try and troubleshoot why this is happening, (in AssetGateway).

Also tidied up some existing logging.