### PR TITLE
Update AssetShared and TenureShared libraries

### DIFF
--- a/HousingManagementSystemApi.Tests/HousingManagementSystemApi.Tests.csproj
+++ b/HousingManagementSystemApi.Tests/HousingManagementSystemApi.Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.1.0" />
     <PackageReference Include="Hackney.HACT.Dtos" Version="1.1.1" />
-    <PackageReference Include="Hackney.Shared.Tenure" Version="0.11.0" />
+    <PackageReference Include="Hackney.Shared.Tenure" Version="0.14.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />

--- a/HousingManagementSystemApi/HousingManagementSystemApi.csproj
+++ b/HousingManagementSystemApi/HousingManagementSystemApi.csproj
@@ -10,8 +10,8 @@
     <PackageReference Include="Dapper" Version="2.0.123" />
     <PackageReference Include="Hackney.HousingRepairsOnline.Authentication" Version="1.2.0" />
     <PackageReference Include="Hackney.HACT.Dtos" Version="1.1.1" />
-    <PackageReference Include="Hackney.Shared.Asset" Version="0.10.0" />
-    <PackageReference Include="Hackney.Shared.Tenure" Version="0.11.0" />
+    <PackageReference Include="Hackney.Shared.Asset" Version="0.27.0" />
+    <PackageReference Include="Hackney.Shared.Tenure" Version="0.14.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
     <PackageReference Include="Moq.Dapper" Version="1.0.4" />
     <PackageReference Include="Sentry.AspNetCore" Version="3.13.0" />


### PR DESCRIPTION
Tenure `0.14.0` was a requirement of Asset `0.27.0`.