### PR TITLE
Upgrade the Asset-Shared version to v0.31.0.

### DIFF
--- a/HousingManagementSystemApi/HousingManagementSystemApi.csproj
+++ b/HousingManagementSystemApi/HousingManagementSystemApi.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Dapper" Version="2.0.123" />
     <PackageReference Include="Hackney.HousingRepairsOnline.Authentication" Version="1.2.0" />
     <PackageReference Include="Hackney.HACT.Dtos" Version="1.1.1" />
-    <PackageReference Include="Hackney.Shared.Asset" Version="0.27.0" />
+    <PackageReference Include="Hackney.Shared.Asset" Version="0.31.0" />
     <PackageReference Include="Hackney.Shared.Tenure" Version="0.14.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
     <PackageReference Include="Moq.Dapper" Version="1.0.4" />


### PR DESCRIPTION
# What:
 - An upgrade to the `Shared.Asset` package version from `v0.27.0` to `v0.31.0`.

# Notes:
 - As far as I've glanced over the application's code, the new extra fields added within [this](https://github.com/LBHackney-IT/asset-shared/pull/36) package version shouldn't affect any functionality within the application.