### PR TITLE
MR-857 Cautionary Alerts for HROL

### DIFF
--- a/HousingManagementSystemApi.Tests/GatewaysTests/RepairsHubAlertGatewayTests.cs
+++ b/HousingManagementSystemApi.Tests/GatewaysTests/RepairsHubAlertGatewayTests.cs
@@ -35,7 +35,7 @@ namespace HousingManagementSystemApi.Tests.GatewaysTests
         {
             _mockHttp = new MockHttpMessageHandler();
 
-            _mockHttp.When($"location-alerts")
+            _mockHttp.When($"*location-alerts")
                 .Respond("application/json", _repairsHubAlertResponse);
 
             var httpClient = _mockHttp.ToHttpClient();
@@ -48,7 +48,7 @@ namespace HousingManagementSystemApi.Tests.GatewaysTests
 
         [Theory]
         [MemberData(nameof(InvalidArgumentTestData))]
-        public async void GivenAnInvalidPropertyReference_WhenGettingAlerts_ThenAnExceptionIsThrown<T>(T exception, string propRef) where T : Exception
+        public async void GivenAnInvalidPropertyReference_WhenGettingAlerts_ThenAnExceptionIsThrown(string propRef)
         {
             // Arrange
 
@@ -56,14 +56,14 @@ namespace HousingManagementSystemApi.Tests.GatewaysTests
             Func<Task> act = async () => await _systemUnderTest.GetLocationAlerts(propRef);
 
             // Assert
-            await act.Should().ThrowExactlyAsync<T>();
+            await act.Should().ThrowExactlyAsync<ArgumentException>();
         }
 
         public static IEnumerable<object[]> InvalidArgumentTestData()
         {
-            yield return new object[] { new ArgumentNullException(), null };
-            yield return new object[] { new ArgumentException(), "" };
-            yield return new object[] { new ArgumentException(), " " };
+            yield return new object[] { null };
+            yield return new object[] { "" };
+            yield return new object[] { " " };
         }
 
         [Fact]

--- a/HousingManagementSystemApi.Tests/GatewaysTests/RepairsHubAlertGatewayTests.cs
+++ b/HousingManagementSystemApi.Tests/GatewaysTests/RepairsHubAlertGatewayTests.cs
@@ -1,0 +1,93 @@
+namespace HousingManagementSystemApi.Tests.GatewaysTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using Gateways;
+    using Moq;
+    using RichardSzalay.MockHttp;
+    using Xunit;
+
+    public class RepairsHubAlertsGatewayTests
+    {
+        private readonly Mock<IHttpClientFactory> _httpClientFactory;
+        private readonly RepairsHubAlertsGateway _systemUnderTest;
+
+        private readonly string _repairsHubAlertResponse = @"{
+
+    ""Alerts"": [
+      {
+        ""AlertCode"": ""VA"",
+        ""Description"": ""Test Alert Description"",
+        ""EndDate"": ""2026-01-01"",
+        ""StartDate"": ""2021-01-01""
+      }
+    ],
+  ""Reference"": ""TEST REF""
+}";
+
+        private readonly MockHttpMessageHandler _mockHttp;
+
+        public RepairsHubAlertsGatewayTests()
+        {
+            _mockHttp = new MockHttpMessageHandler();
+
+            _mockHttp.When($"location-alerts")
+                .Respond("application/json", _repairsHubAlertResponse);
+
+            var httpClient = _mockHttp.ToHttpClient();
+            httpClient.BaseAddress = new Uri("http://localhost/");
+
+            _httpClientFactory = new Mock<IHttpClientFactory>();
+            _httpClientFactory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(httpClient);
+            _systemUnderTest = new RepairsHubAlertsGateway(_httpClientFactory.Object);
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidArgumentTestData))]
+        public async void GivenAnInvalidPropertyReference_WhenGettingAlerts_ThenAnExceptionIsThrown<T>(T exception, string propRef) where T : Exception
+        {
+            // Arrange
+
+            // Act
+            Func<Task> act = async () => await _systemUnderTest.GetLocationAlerts(propRef);
+
+            // Assert
+            await act.Should().ThrowExactlyAsync<T>();
+        }
+
+        public static IEnumerable<object[]> InvalidArgumentTestData()
+        {
+            yield return new object[] { new ArgumentNullException(), null };
+            yield return new object[] { new ArgumentException(), "" };
+            yield return new object[] { new ArgumentException(), " " };
+        }
+
+        [Fact]
+        public async void GivenAValidPropertyReference_WhenGettingAlerts_ThenNoExceptionIsThrown()
+        {
+            // Arrange
+
+            // Act
+            Func<Task> act = async () => await _systemUnderTest.GetLocationAlerts("00023400");
+
+            // Assert
+            await act.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async void GivenAValidPropertyReference_WhenGettingAlerts_ThenAddressesAreRetrievedFromApi()
+        {
+            // Arrange
+
+            // Act
+            var results = await _systemUnderTest.GetLocationAlerts("00023400");
+
+            // Assert
+            Assert.True(results.Alerts.Any());
+        }
+    }
+}

--- a/HousingManagementSystemApi.Tests/UseCasesTests/VerifyPropertyEligibilityUseCaseTests.cs
+++ b/HousingManagementSystemApi.Tests/UseCasesTests/VerifyPropertyEligibilityUseCaseTests.cs
@@ -8,6 +8,7 @@ namespace HousingManagementSystemApi.Tests.UseCasesTests
     using Hackney.Shared.Tenure.Domain;
     using HousingManagementSystemApi.Gateways;
     using HousingManagementSystemApi.UseCases;
+    using HousingManagementSystemApi.Models.RepairsHub;
     using Microsoft.Extensions.Logging.Abstractions;
     using Moq;
     using Xunit;
@@ -17,6 +18,7 @@ namespace HousingManagementSystemApi.Tests.UseCasesTests
         private readonly Mock<IAssetGateway> _retrieveAssetGateway;
         private readonly Mock<ITenureGateway> _tenureGateway;
         private readonly VerifyPropertyEligibilityUseCase _sut;
+        private readonly Mock<IRepairsHubAlertsGateway> _alertsGatewayMock;
 
         public static readonly IEnumerable<AssetType> EligibleAssetTypes = new[]
 {
@@ -30,11 +32,24 @@ namespace HousingManagementSystemApi.Tests.UseCasesTests
             TenureTypes.Freehold
         };
 
+        private readonly AlertsViewModel noAlerts = new()
+        {
+            Alerts = new List<CautionaryAlertViewModel>()
+        };
+
         public VerifyPropertyEligibilityUseCaseTests()
         {
             _retrieveAssetGateway = new Mock<IAssetGateway>();
             _tenureGateway = new Mock<ITenureGateway>();
-            _sut = new VerifyPropertyEligibilityUseCase(_retrieveAssetGateway.Object, EligibleAssetTypes, _tenureGateway.Object, eligibleTenureTypes, new NullLogger<VerifyPropertyEligibilityUseCase>());
+            _alertsGatewayMock = new Mock<IRepairsHubAlertsGateway>();
+
+            _alertsGatewayMock.Setup(s => s.GetPersonAlerts(It.IsAny<string>()))
+                .ReturnsAsync(noAlerts);
+
+            _alertsGatewayMock.Setup(s => s.GetLocationAlerts(It.IsAny<string>()))
+                .ReturnsAsync(noAlerts);
+
+            _sut = new VerifyPropertyEligibilityUseCase(_retrieveAssetGateway.Object, EligibleAssetTypes, _tenureGateway.Object, eligibleTenureTypes, new NullLogger<VerifyPropertyEligibilityUseCase>(), _alertsGatewayMock.Object);
         }
 
         [Fact]
@@ -235,5 +250,97 @@ namespace HousingManagementSystemApi.Tests.UseCasesTests
             Assert.False(result.PropertyEligible);
             Assert.Contains("is managed by a TMO", result.Reason);
         }
+
+        [Fact]
+        public async Task GivenAPropertyWithLocationAlerts_WhenUseCaseIsExecuted_ThenShouldBeAFailureResult()
+        {
+            // Arrange
+            const string HouseThatExists = "01234567";
+
+            _retrieveAssetGateway.Setup(x => x.RetrieveAsset(HouseThatExists))
+                .ReturnsAsync(new AssetResponseObject
+                {
+                    AssetType = AssetType.Dwelling,
+                    Tenure = new AssetTenureResponseObject
+                    {
+                        Id = "TEN001"
+                    },
+                    AssetManagement = new AssetManagement
+                    {
+                        IsTMOManaged = false,
+                    }
+                });
+
+            _tenureGateway.Setup(x => x.RetrieveTenureType("TEN001"))
+                .ReturnsAsync(new TenureInformation { TenureType = TenureTypes.Secure });
+
+            _alertsGatewayMock.Setup(s => s.GetLocationAlerts(It.IsAny<string>()))
+                .ReturnsAsync(new AlertsViewModel
+                {
+                    Alerts = new List<CautionaryAlertViewModel>
+                    {
+                        new CautionaryAlertViewModel
+                        {
+                            Type = "VA",
+                            Comments = "Violent resident"
+                        }
+                    },
+                    Reference = "TEST REFERENCE"
+                });
+            ;
+
+            // Act
+            var result = await _sut.Execute(HouseThatExists);
+
+            // Assert
+            Assert.False(result.PropertyEligible);
+            Assert.Contains("not eligable for RHOL due to having 1 active Location Alert", result.Reason);
+        }
+
+        //[Fact]
+        //public async Task GivenAPropertyWithPersonAlerts_WhenUseCaseIsExecuted_ThenShouldBeAFailureResult()
+        //{
+        //    // Arrange
+        //    const string HouseThatExists = "01234567";
+
+        //    _retrieveAssetGateway.Setup(x => x.RetrieveAsset(HouseThatExists))
+        //        .ReturnsAsync(new AssetResponseObject
+        //        {
+        //            AssetType = AssetType.Dwelling,
+        //            Tenure = new AssetTenureResponseObject
+        //            {
+        //                Id = "TEN001"
+        //            },
+        //            AssetManagement = new AssetManagement
+        //            {
+        //                IsTMOManaged = false,
+        //            }
+        //        });
+
+        //    _tenureGateway.Setup(x => x.RetrieveTenureType("TEN001"))
+        //        .ReturnsAsync(new TenureInformation { TenureType = TenureTypes.Secure });
+
+        //    _alertsGatewayMock.Setup(s => s.GetPersonAlerts(It.IsAny<string>()))
+        //        .ReturnsAsync(new AlertsViewModel
+        //        {
+        //            Alerts = new List<CautionaryAlertViewModel>
+        //            {
+        //                new CautionaryAlertViewModel
+        //                {
+        //                    Type = "VA",
+        //                    Comments = "Violent resident"
+        //                }
+        //            },
+        //            Reference = "TEST REFERENCE"
+        //        });
+        //    ;
+
+        //    // Act
+        //    var result = await _sut.Execute(HouseThatExists);
+
+        //    // Assert
+        //    Assert.False(result.PropertyEligible);
+        //    Assert.Contains("not eligable for RHOL due to having 1 active Person Alert", result.Reason);
+        //}
     }
 }

--- a/HousingManagementSystemApi.Tests/UseCasesTests/VerifyPropertyEligibilityUseCaseTests.cs
+++ b/HousingManagementSystemApi.Tests/UseCasesTests/VerifyPropertyEligibilityUseCaseTests.cs
@@ -43,9 +43,6 @@ namespace HousingManagementSystemApi.Tests.UseCasesTests
             _tenureGateway = new Mock<ITenureGateway>();
             _alertsGatewayMock = new Mock<IRepairsHubAlertsGateway>();
 
-            _alertsGatewayMock.Setup(s => s.GetPersonAlerts(It.IsAny<string>()))
-                .ReturnsAsync(noAlerts);
-
             _alertsGatewayMock.Setup(s => s.GetLocationAlerts(It.IsAny<string>()))
                 .ReturnsAsync(noAlerts);
 

--- a/HousingManagementSystemApi.Tests/UseCasesTests/VerifyPropertyEligibilityUseCaseTests.cs
+++ b/HousingManagementSystemApi.Tests/UseCasesTests/VerifyPropertyEligibilityUseCaseTests.cs
@@ -221,37 +221,6 @@ namespace HousingManagementSystemApi.Tests.UseCasesTests
         }
 
         [Fact]
-        public async Task GivenATmoManagedProperty_WhenUseCaseIsExecuted_ThenShouldBeAFailureResult()
-        {
-            // Arrange
-            const string HouseThatExists = "01234567";
-
-            _retrieveAssetGateway.Setup(x => x.RetrieveAsset(HouseThatExists))
-                .ReturnsAsync(new AssetResponseObject
-                {
-                    AssetType = AssetType.Dwelling,
-                    Tenure = new AssetTenureResponseObject
-                    {
-                        Id = "TEN001"
-                    },
-                    AssetManagement = new AssetManagement
-                    {
-                        IsTMOManaged = true,
-                    }
-                });
-
-            _tenureGateway.Setup(x => x.RetrieveTenureType("TEN001"))
-                .ReturnsAsync(new TenureInformation { TenureType = TenureTypes.Secure });
-
-            // Act
-            var result = await _sut.Execute(HouseThatExists);
-
-            // Assert
-            Assert.False(result.PropertyEligible);
-            Assert.Contains("is managed by a TMO", result.Reason);
-        }
-
-        [Fact]
         public async Task GivenAPropertyWithLocationAlerts_WhenUseCaseIsExecuted_ThenShouldBeAFailureResult()
         {
             // Arrange

--- a/HousingManagementSystemApi.Tests/UseCasesTests/VerifyPropertyEligibilityUseCaseTests.cs
+++ b/HousingManagementSystemApi.Tests/UseCasesTests/VerifyPropertyEligibilityUseCaseTests.cs
@@ -7,8 +7,8 @@ namespace HousingManagementSystemApi.Tests.UseCasesTests
     using Hackney.Shared.Asset.Domain;
     using Hackney.Shared.Tenure.Domain;
     using HousingManagementSystemApi.Gateways;
-    using HousingManagementSystemApi.UseCases;
     using HousingManagementSystemApi.Models.RepairsHub;
+    using HousingManagementSystemApi.UseCases;
     using Microsoft.Extensions.Logging.Abstractions;
     using Moq;
     using Xunit;

--- a/HousingManagementSystemApi.Tests/UseCasesTests/VerifyPropertyEligibilityUseCaseTests.cs
+++ b/HousingManagementSystemApi.Tests/UseCasesTests/VerifyPropertyEligibilityUseCaseTests.cs
@@ -296,51 +296,5 @@ namespace HousingManagementSystemApi.Tests.UseCasesTests
             Assert.False(result.PropertyEligible);
             Assert.Contains("not eligable for RHOL due to having 1 active Location Alert", result.Reason);
         }
-
-        //[Fact]
-        //public async Task GivenAPropertyWithPersonAlerts_WhenUseCaseIsExecuted_ThenShouldBeAFailureResult()
-        //{
-        //    // Arrange
-        //    const string HouseThatExists = "01234567";
-
-        //    _retrieveAssetGateway.Setup(x => x.RetrieveAsset(HouseThatExists))
-        //        .ReturnsAsync(new AssetResponseObject
-        //        {
-        //            AssetType = AssetType.Dwelling,
-        //            Tenure = new AssetTenureResponseObject
-        //            {
-        //                Id = "TEN001"
-        //            },
-        //            AssetManagement = new AssetManagement
-        //            {
-        //                IsTMOManaged = false,
-        //            }
-        //        });
-
-        //    _tenureGateway.Setup(x => x.RetrieveTenureType("TEN001"))
-        //        .ReturnsAsync(new TenureInformation { TenureType = TenureTypes.Secure });
-
-        //    _alertsGatewayMock.Setup(s => s.GetPersonAlerts(It.IsAny<string>()))
-        //        .ReturnsAsync(new AlertsViewModel
-        //        {
-        //            Alerts = new List<CautionaryAlertViewModel>
-        //            {
-        //                new CautionaryAlertViewModel
-        //                {
-        //                    Type = "VA",
-        //                    Comments = "Violent resident"
-        //                }
-        //            },
-        //            Reference = "TEST REFERENCE"
-        //        });
-        //    ;
-
-        //    // Act
-        //    var result = await _sut.Execute(HouseThatExists);
-
-        //    // Assert
-        //    Assert.False(result.PropertyEligible);
-        //    Assert.Contains("not eligable for RHOL due to having 1 active Person Alert", result.Reason);
-        //}
     }
 }

--- a/HousingManagementSystemApi/Gateways/HttpClientNames.cs
+++ b/HousingManagementSystemApi/Gateways/HttpClientNames.cs
@@ -6,4 +6,5 @@ public static class HttpClientNames
     public const string Properties = "Properties";
     public const string Asset = "Asset";
     public const string TenureInformation = "TenureInformation";
+    public const string RepairsHubAlerts = "RepairsHubAlerts";
 }

--- a/HousingManagementSystemApi/Gateways/IRepairsHubAlertsGateway.cs
+++ b/HousingManagementSystemApi/Gateways/IRepairsHubAlertsGateway.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+using HousingManagementSystemApi.Models.RepairsHub;
+
+namespace HousingManagementSystemApi.Gateways
+{
+    public interface IRepairsHubAlertsGateway
+    {
+        public Task<AlertsViewModel> GetPersonAlerts(string tenancyAgreementReference);
+        public Task<AlertsViewModel> GetLocationAlerts(string propertyReference);
+    }
+}

--- a/HousingManagementSystemApi/Gateways/IRepairsHubAlertsGateway.cs
+++ b/HousingManagementSystemApi/Gateways/IRepairsHubAlertsGateway.cs
@@ -5,7 +5,6 @@ namespace HousingManagementSystemApi.Gateways
 {
     public interface IRepairsHubAlertsGateway
     {
-        public Task<AlertsViewModel> GetPersonAlerts(string tenancyAgreementReference);
         public Task<AlertsViewModel> GetLocationAlerts(string propertyReference);
     }
 }

--- a/HousingManagementSystemApi/Gateways/RepairsHubAlertsGateway.cs
+++ b/HousingManagementSystemApi/Gateways/RepairsHubAlertsGateway.cs
@@ -2,9 +2,11 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
-using System.Text;
+using System;
 using System.Text.Json;
 using System.Threading.Tasks;
+using HousingManagementSystemApi.Models.RepairsHub;
+using Amazon.Lambda.Core;
 
 namespace HousingManagementSystemApi.Gateways
 {
@@ -17,7 +19,65 @@ namespace HousingManagementSystemApi.Gateways
             _client = httpClientFactory.CreateClient(HttpClientNames.RepairsHubAlerts);
         }
 
-        //[Route("{tenancyAgreementReference}/person-alerts")]
-        //[Route("{propertyReference}/location-alerts")]
+        public async Task<AlertsViewModel> GetPersonAlerts(string tenancyAgreementReference)
+        {
+            if (string.IsNullOrWhiteSpace(tenancyAgreementReference)) throw new ArgumentException(tenancyAgreementReference, nameof(tenancyAgreementReference));
+
+            LambdaLogger.Log("Starting person alert retrieval for tenancy " + tenancyAgreementReference);
+
+            string uri = $"properties/{tenancyAgreementReference}/person-alerts";
+
+            var request = new HttpRequestMessage(HttpMethod.Get, uri);
+
+            LambdaLogger.Log("About to get person alerts at " + uri);
+
+            var response = await _client.SendAsync(request);
+
+            AlertsViewModel alertResult = null;
+
+            if (response.StatusCode == HttpStatusCode.OK)
+            {
+                alertResult = await response.Content.ReadFromJsonAsync<AlertsViewModel>();
+
+                LambdaLogger.Log($"Successfully got {alertResult.Alerts.Count} person alerts for tenancy " + tenancyAgreementReference);
+            }
+            else
+            {
+                LambdaLogger.Log($"Call to {uri} was unsuccessful with error {response.StatusCode}, reason: {response.ReasonPhrase}");
+            }
+
+            return alertResult;
+        }
+
+        public async Task<AlertsViewModel> GetLocationAlerts(string propertyReference)
+        {
+            if (string.IsNullOrWhiteSpace(propertyReference))
+                throw new ArgumentException(propertyReference, nameof(propertyReference));
+
+            LambdaLogger.Log("Starting person alert retrieval for location " + propertyReference);
+
+            string uri = $"properties/{propertyReference}/location-alerts";
+
+            var request = new HttpRequestMessage(HttpMethod.Get, uri);
+
+            LambdaLogger.Log("About to get location alerts at " + uri);
+
+            var response = await _client.SendAsync(request);
+
+            AlertsViewModel alertResult = null;
+
+            if (response.StatusCode == HttpStatusCode.OK)
+            {
+                alertResult = await response.Content.ReadFromJsonAsync<AlertsViewModel>();
+
+                LambdaLogger.Log($"Successfully got {alertResult.Alerts.Count} location alerts for tenancy " + propertyReference);
+            }
+            else
+            {
+                LambdaLogger.Log($"Call to {uri} was unsuccessful with error {response.StatusCode}, reason: {response.ReasonPhrase}");
+            }
+
+            return alertResult;
+        }
     }
 }

--- a/HousingManagementSystemApi/Gateways/RepairsHubAlertsGateway.cs
+++ b/HousingManagementSystemApi/Gateways/RepairsHubAlertsGateway.cs
@@ -19,37 +19,6 @@ namespace HousingManagementSystemApi.Gateways
             _client = httpClientFactory.CreateClient(HttpClientNames.RepairsHubAlerts);
         }
 
-        public async Task<AlertsViewModel> GetPersonAlerts(string tenancyAgreementReference)
-        {
-            if (string.IsNullOrWhiteSpace(tenancyAgreementReference))
-                throw new ArgumentException(tenancyAgreementReference, nameof(tenancyAgreementReference));
-
-            LambdaLogger.Log("Starting person alert retrieval for tenancy " + tenancyAgreementReference);
-
-            string uri = $"properties/{tenancyAgreementReference}/person-alerts";
-
-            var request = new HttpRequestMessage(HttpMethod.Get, uri);
-
-            LambdaLogger.Log("About to get person alerts at " + uri);
-
-            var response = await _client.SendAsync(request);
-
-            AlertsViewModel alertResult = null;
-
-            if (response.StatusCode == HttpStatusCode.OK)
-            {
-                alertResult = await response.Content.ReadFromJsonAsync<AlertsViewModel>();
-
-                LambdaLogger.Log($"Successfully got {alertResult.Alerts.Count} person alerts for tenancy " + tenancyAgreementReference);
-            }
-            else
-            {
-                LambdaLogger.Log($"Call to {uri} was unsuccessful with error {response.StatusCode}, reason: {response.ReasonPhrase}");
-            }
-
-            return alertResult;
-        }
-
         public async Task<AlertsViewModel> GetLocationAlerts(string propertyReference)
         {
             if (string.IsNullOrWhiteSpace(propertyReference))

--- a/HousingManagementSystemApi/Gateways/RepairsHubAlertsGateway.cs
+++ b/HousingManagementSystemApi/Gateways/RepairsHubAlertsGateway.cs
@@ -1,12 +1,12 @@
+using System;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
-using System;
 using System.Text.Json;
 using System.Threading.Tasks;
-using HousingManagementSystemApi.Models.RepairsHub;
 using Amazon.Lambda.Core;
+using HousingManagementSystemApi.Models.RepairsHub;
 
 namespace HousingManagementSystemApi.Gateways
 {
@@ -21,7 +21,8 @@ namespace HousingManagementSystemApi.Gateways
 
         public async Task<AlertsViewModel> GetPersonAlerts(string tenancyAgreementReference)
         {
-            if (string.IsNullOrWhiteSpace(tenancyAgreementReference)) throw new ArgumentException(tenancyAgreementReference, nameof(tenancyAgreementReference));
+            if (string.IsNullOrWhiteSpace(tenancyAgreementReference))
+                throw new ArgumentException(tenancyAgreementReference, nameof(tenancyAgreementReference));
 
             LambdaLogger.Log("Starting person alert retrieval for tenancy " + tenancyAgreementReference);
 

--- a/HousingManagementSystemApi/Gateways/RepairsHubAlertsGateway.cs
+++ b/HousingManagementSystemApi/Gateways/RepairsHubAlertsGateway.cs
@@ -34,18 +34,15 @@ namespace HousingManagementSystemApi.Gateways
 
             var response = await _client.SendAsync(request);
 
-            AlertsViewModel alertResult = null;
-
-            if (response.StatusCode == HttpStatusCode.OK)
-            {
-                alertResult = await response.Content.ReadFromJsonAsync<AlertsViewModel>();
-
-                LambdaLogger.Log($"Successfully got {alertResult.Alerts.Count} location alerts for tenancy " + propertyReference);
-            }
-            else
+            if (response.StatusCode != HttpStatusCode.OK)
             {
                 LambdaLogger.Log($"Call to {uri} was unsuccessful with error {response.StatusCode}, reason: {response.ReasonPhrase}");
+                return null;
             }
+
+            var alertResult = await response.Content.ReadFromJsonAsync<AlertsViewModel>();
+
+            LambdaLogger.Log($"Successfully got {alertResult.Alerts.Count} location alerts for tenancy " + propertyReference);
 
             return alertResult;
         }

--- a/HousingManagementSystemApi/Gateways/RepairsHubAlertsGateway.cs
+++ b/HousingManagementSystemApi/Gateways/RepairsHubAlertsGateway.cs
@@ -1,0 +1,23 @@
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace HousingManagementSystemApi.Gateways
+{
+    public class RepairsHubAlertsGateway : IRepairsHubAlertsGateway
+    {
+        private readonly HttpClient _client;
+
+        public RepairsHubAlertsGateway(IHttpClientFactory httpClientFactory)
+        {
+            _client = httpClientFactory.CreateClient(HttpClientNames.RepairsHubAlerts);
+        }
+
+        //[Route("{tenancyAgreementReference}/person-alerts")]
+        //[Route("{propertyReference}/location-alerts")]
+    }
+}

--- a/HousingManagementSystemApi/Models/RepairsHub/AlertViewModel.cs
+++ b/HousingManagementSystemApi/Models/RepairsHub/AlertViewModel.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace HousingManagementSystemApi.Models.RepairsHub
+{
+    public class AlertsViewModel
+    {
+        public string Reference { get; set; }
+        public List<CautionaryAlertViewModel> Alerts { get; set; }
+    }
+}

--- a/HousingManagementSystemApi/Models/RepairsHub/CautionaryAlertViewModel.cs
+++ b/HousingManagementSystemApi/Models/RepairsHub/CautionaryAlertViewModel.cs
@@ -1,0 +1,25 @@
+namespace HousingManagementSystemApi.Models.RepairsHub
+{
+    public class CautionaryAlertViewModel
+    {
+        /// <summary>
+        /// Gets or Sets AlertCode
+        /// </summary>
+        public string Type { get; set; }
+
+        /// <summary>
+        /// Gets or Sets Description
+        /// </summary>
+        public string Comments { get; set; }
+
+        /// <summary>
+        /// Gets or Sets StartDate
+        /// </summary>
+        public string StartDate { get; set; }
+
+        /// <summary>
+        /// Gets or Sets EndDate
+        /// </summary>
+        public string EndDate { get; set; }
+    }
+}

--- a/HousingManagementSystemApi/Startup.cs
+++ b/HousingManagementSystemApi/Startup.cs
@@ -110,9 +110,10 @@ namespace HousingManagementSystemApi
         private static void AddHttpClients(IServiceCollection services)
         {
             AddHttpClient(services, HttpClientNames.HousingSearch, "HOUSING_SEARCH_API_URI", "HOUSING_SEARCH_API_KEY");
-            AddHttpClient(services, HttpClientNames.Properties, "PROPERTIES_API_URI", "PROPERTIES_API_KEY");
+            AddHttpClient(services, HttpClientNames.Properties, "PROPERTIES_API_URI", "PROPERTIES_API_KEY"); //v1 (legacy properties)
             AddHttpClient(services, HttpClientNames.Asset, "HOUSING_ASSET_API_URI", "HOUSING_ASSET_API_KEY");
             AddHttpClient(services, HttpClientNames.TenureInformation, "TENURE_INFORMATION_API_URI", "TENURE_INFORMATION_API_KEY");
+            AddHttpClient(services, HttpClientNames.RepairsHubAlerts, "REPAIRS_HUB_PROPERTIES_URL", "REPAIRS_HUB_PROPERTIES_API_KEY"); //v2 properties (RH)
         }
 
         private static void AddHttpClient(IServiceCollection services, string clientName, string apiUriEnvVarName, string apiKey)

--- a/HousingManagementSystemApi/Startup.cs
+++ b/HousingManagementSystemApi/Startup.cs
@@ -59,7 +59,8 @@ namespace HousingManagementSystemApi
                 var eligibleAssets = EligibleAssetTypes;
                 var eligibleTenureTypes = EligibleTenureTypes;
                 var logger = s.GetService<ILogger<VerifyPropertyEligibilityUseCase>>();
-                return new VerifyPropertyEligibilityUseCase(assetGateway, eligibleAssets, tenureGateway, eligibleTenureTypes, logger);
+                var repairsHubAlertsGateway = s.GetService<IRepairsHubAlertsGateway>();
+                return new VerifyPropertyEligibilityUseCase(assetGateway, eligibleAssets, tenureGateway, eligibleTenureTypes, logger, repairsHubAlertsGateway);
             });
 
             AddHttpClients(services);
@@ -68,6 +69,7 @@ namespace HousingManagementSystemApi
             services.AddTransient<IAssetGateway, AssetGateway>();
             //services.AddTransient<IAddressesGateway, PropertiesGateway>();
             services.AddTransient<IAddressesGateway, HousingSearchGateway>();
+            services.AddTransient<IRepairsHubAlertsGateway, RepairsHubAlertsGateway>();
 
             services.AddSwaggerGen(c =>
             {
@@ -113,22 +115,27 @@ namespace HousingManagementSystemApi
             AddHttpClient(services, HttpClientNames.Properties, "PROPERTIES_API_URI", "PROPERTIES_API_KEY"); //v1 (legacy properties)
             AddHttpClient(services, HttpClientNames.Asset, "HOUSING_ASSET_API_URI", "HOUSING_ASSET_API_KEY");
             AddHttpClient(services, HttpClientNames.TenureInformation, "TENURE_INFORMATION_API_URI", "TENURE_INFORMATION_API_KEY");
-            AddHttpClient(services, HttpClientNames.RepairsHubAlerts, "REPAIRS_HUB_PROPERTIES_URL", "REPAIRS_HUB_PROPERTIES_API_KEY"); //v2 properties (RH)
+            AddHttpClient(services, HttpClientNames.RepairsHubAlerts, "REPAIRS_HUB_PROPERTIES_URL", "REPAIRS_HUB_PROPERTIES_API_KEY", true); //v2 properties (RH)
         }
 
-        private static void AddHttpClient(IServiceCollection services, string clientName, string apiUriEnvVarName, string apiKey)
+        private static void AddHttpClient(IServiceCollection services, string clientName, string apiUriEnvVarName, string apiKey, bool addLegacyHeader = false)
         {
             var uri = new Uri(GetEnvironmentVariable(apiUriEnvVarName));
             var key = GetEnvironmentVariable(apiKey);
-            AddClient(services, clientName, uri, key);
+            AddClient(services, clientName, uri, key, addLegacyHeader);
         }
 
-        private static void AddClient(IServiceCollection services, string clientName, Uri uri, string key)
+        private static void AddClient(IServiceCollection services, string clientName, Uri uri, string key, bool addLegacyHeader)
         {
             services.AddHttpClient(clientName, c =>
             {
                 c.BaseAddress = uri;
                 c.DefaultRequestHeaders.Add("Authorization", key);
+                if (addLegacyHeader)
+                {
+                    c.DefaultRequestHeaders.Add("x-hackney-user", key);
+                    c.DefaultRequestHeaders.Add("Accept", "application/json");
+                }
             });
         }
     }

--- a/HousingManagementSystemApi/UseCases/VerifyPropertyEligibilityUseCase.cs
+++ b/HousingManagementSystemApi/UseCases/VerifyPropertyEligibilityUseCase.cs
@@ -103,17 +103,6 @@ namespace HousingManagementSystemApi.UseCases
                 return new PropertyEligibilityResult(false, locationFailureText);
             }
 
-            //_logger.LogInformation("About to get person alerts for: ", asset?.Tenure?.Id);
-
-            //var personAlerts = await _repairsHubAlertGateway.GetPersonAlerts(asset?.Tenure?.Id);
-
-            //if (personAlerts.Alerts.Any())
-            //{
-            //    var personFailureText = $"Tenure {asset?.Tenure?.Id} is not eligable for RHOL due to having {personAlerts.Alerts.Count} active Person Alert(s)";
-            //    _logger.LogInformation(personFailureText);
-            //    return new PropertyEligibilityResult(false, personFailureText);
-            //}
-
             return new PropertyEligibilityResult(true, "The property is valid");
         }
     }

--- a/HousingManagementSystemApi/serverless.yml
+++ b/HousingManagementSystemApi/serverless.yml
@@ -42,6 +42,8 @@ functions:
       HOUSING_ASSET_API_KEY: ${ssm:/HousingManagementSystemApi/${self:provider.stage}/housing-asset-api-key}
       TENURE_INFORMATION_API_URI: ${ssm:/HousingManagementSystemApi/${self:provider.stage}/tenure-information-api-uri}
       TENURE_INFORMATION_API_KEY: ${ssm:/HousingManagementSystemApi/${self:provider.stage}/tenure-information-api-key}
+      REPAIRS_HUB_PROPERTIES_URL: ${ssm:/HousingManagementSystemApi/${self:provider.stage}/repairs-hub-properties-api-uri}
+      REPAIRS_HUB_PROPERTIES_API_KEY: ${ssm:/HousingManagementSystemApi/${self:provider.stage}/repairs-hub-properties-api-key}
     events:
       - http:
           path: /{proxy+}


### PR DESCRIPTION
- Context: https://hackney.atlassian.net/browse/MR-857
- The HROL (OnlineRepairs) portal did not check that operatives were being exposed to a potentially dangerous situation vis-a-vis cautionary alerts
- This was a stakeholder-accepted limitation during initial deployment of HROL, however, now that has been forgotten, an urgent fix is needed
- A note an architecture: The reviewer will notice that the call is made via RepairsHub backend, rather than via CC API directly. The reasons for this are twofold:
- 1. To keep the notification mechanism consistent for RepairsHub and HROL.
- 2. To minimise the attack surface (especially with respect to DDOS vulnerability) due to HROL being an unauthenticated platform (for more details on this please refer to my Community of Practice talk on application auth or view the slides [here](https://docs.google.com/presentation/d/10tfvl4WTXJfCk9SrJc5f7misJYB7WOx79G3vKuaQB64/edit?usp=sharing))